### PR TITLE
sercon: do not screwup the xterm on the serial console

### DIFF
--- a/src/sercon.c
+++ b/src/sercon.c
@@ -99,27 +99,12 @@ static void sercon_putchar(u8 chr)
     }
 }
 
-static void sercon_term_reset(void)
-{
-    sercon_putchar('\x1b');
-    sercon_putchar('c');
-}
-
 static void sercon_term_clear_screen(void)
 {
     sercon_putchar('\x1b');
     sercon_putchar('[');
     sercon_putchar('2');
     sercon_putchar('J');
-}
-
-static void sercon_term_no_linewrap(void)
-{
-    sercon_putchar('\x1b');
-    sercon_putchar('[');
-    sercon_putchar('?');
-    sercon_putchar('7');
-    sercon_putchar('l');
 }
 
 static void sercon_term_cursor_goto(u8 row, u8 col)
@@ -308,7 +293,6 @@ static void sercon_lazy_putchar(u8 chr, u8 attr, u8 teletype)
 /* Set video mode */
 static void sercon_1000(struct bregs *regs)
 {
-    u8 clearscreen = !(regs->al & 0x80);
     u8 mode = regs->al & 0x7f;
     u8 rows, cols;
 
@@ -345,11 +329,6 @@ static void sercon_1000(struct bregs *regs)
     SET_LOW(sercon_col_last, 0);
     SET_LOW(sercon_row_last, 0);
     SET_LOW(sercon_attr_last, 0);
-
-    sercon_term_reset();
-    sercon_term_no_linewrap();
-    if (clearscreen)
-        sercon_term_clear_screen();
 }
 
 /* Set text-mode cursor shape */


### PR DESCRIPTION
It's very frustrating to boot with a serial console in qemu and to have it clear the scrollback history of the window, turn off line wrap and otherwise mess with the port.  This patch removes the functions that send those vt100 escape codes.

Maybe there is a better way to configure this functionality?