### PR TITLE
Update farptr.h

### DIFF
--- a/src/farptr.h
+++ b/src/farptr.h
@@ -161,16 +161,22 @@ static inline void insl_fl(u16 port, void *ptr_fl, u16 count) {
     insl(port, (u32*)FLATPTR_TO_OFFSET(ptr_fl), count);
 }
 static inline void outsb_fl(u16 port, void *ptr_fl, u16 count) {
-    SET_SEG(ES, FLATPTR_TO_SEG(ptr_fl));
+    u16 ds = GET_SEG(DS);
+    SET_SEG(DS, FLATPTR_TO_SEG(ptr_fl));
     outsb(port, (u8*)FLATPTR_TO_OFFSET(ptr_fl), count);
+    SET_SEG(DS, ds);
 }
 static inline void outsw_fl(u16 port, void *ptr_fl, u16 count) {
-    SET_SEG(ES, FLATPTR_TO_SEG(ptr_fl));
+    u16 ds = GET_SEG(DS);
+    SET_SEG(DS, FLATPTR_TO_SEG(ptr_fl));
     outsw(port, (u16*)FLATPTR_TO_OFFSET(ptr_fl), count);
+    SET_SEG(DS, ds);
 }
 static inline void outsl_fl(u16 port, void *ptr_fl, u16 count) {
-    SET_SEG(ES, FLATPTR_TO_SEG(ptr_fl));
+    u16 ds = GET_DS(DS);
+    SET_SEG(DS, FLATPTR_TO_SEG(ptr_fl));
     outsl(port, (u32*)FLATPTR_TO_OFFSET(ptr_fl), count);
+    SET_SEG(DS, ds);
 }
 
 #else


### PR DESCRIPTION
Fixing Outs() that should use [DS:SI] and not ES, when running in real mode 16bits. I save DS and restore it after because SeaBIOS use DS 

This will fix a major bug on using BIOS service 0x13 AH=0x42 when using a ATAPI drive and maybe some other SCSI drive when you call BIOS service in real mode 16bits like bootloader